### PR TITLE
Improved wrap condition, button caching and added automatic setting z-index property

### DIFF
--- a/src/jquery.clearsearch.js
+++ b/src/jquery.clearsearch.js
@@ -42,13 +42,17 @@
 					var $this = $(this), btn,
 						divClass = settings.clearClass + '_div';
 
-					if (!$this.parent().hasClass(divClass)) {
+					if ($this.parent().css('position') !== 'relative') {
 						$this.wrap('<div style="position: relative;" class="'
 							+ divClass + '">' + $this.html() + '</div>');
-						$this.after('<a style="position: absolute; cursor: pointer;" class="'
-							+ settings.clearClass + '">' + settings.linkText + '</a>');
+						console.warn('clearSearch input was wrapped with div');
+					} else if (!$this.parent().is(divClass)) {
+						$this.parent().addClass(divClass);
 					}
-					btn = $this.next();
+
+					$this.parent().append('<a style="position: absolute; cursor: pointer;" class="'
+						+ settings.clearClass + '">' + settings.linkText + '</a>');
+					btn = $this.parent().find('.' + settings.clearClass);
 
 					function clearField() {
 						$this.val('').change();
@@ -79,7 +83,8 @@
 								.outerHeight();
 						btn.css({
 							top : height / 2 - btn.height() / 2,
-							left : width - height / 2 - btn.height() / 2
+							left : width - height / 2 - btn.height() / 2,
+							'z-index': $this.css('z-index') || 'initial'
 						});
 					}
 


### PR DESCRIPTION
The condition to **wrap** a target elements was changed. Now if parent container is not relatively positioned, the element wrapping and console output a warning message. Otherwise adding custom class to the parent container.
The next change involves **caching** inserted **button**. This DOM navigation eliminating required element that should be after target input, e.g. labels.
Furthermore, there was auto **setting z-index** property to button same as target element for normal availability